### PR TITLE
[wip] Implement support more non-required traits

### DIFF
--- a/arsert_failure/src/expressions.rs
+++ b/arsert_failure/src/expressions.rs
@@ -131,7 +131,7 @@ impl<V: Debug> Display for UnaryAssertionFailure<V> {
     }
 }
 
-impl<V: 'static + Debug> ExpressionInfo for UnaryAssertionFailure<V> {
+impl<'a, V: 'a + Debug> ExpressionInfo for UnaryAssertionFailure<V> {
     fn expression(&self) -> String {
         format!("{}{}", self.op, self.expr)
     }


### PR DESCRIPTION
In this PR, I'll try to ensure that the following traits are not
required to be implemented on values:

- [x] `Copy` - we should be able to handle only references in assertions.
- [ ] maybe `Debug`? I would like the output to not break if any
  non-debug values are being handled.