### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,4 @@ version="0.0.3-dev" # dep_replace
 proc-macro-hack = "0.5.4"
 
 [dev-dependencies]
-version-sync = "0.6.0"
+version-sync = "0.8.0"


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.